### PR TITLE
fix: gh fetch error hidden

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+_data/ @TomerFi @bennypowers
+_includes/ @bennypowers
+assets/ @bennypowers
+feed/ @bennypowers
+/*.* @bennypowers @TomerFi
+.github/ @TomerFi
+*.njk @bennypowers @TomerFi

--- a/_data/contributors.js
+++ b/_data/contributors.js
@@ -68,12 +68,8 @@ module.exports = async function israelContributors(_configData) {
     return cache.getCachedValue();
   } else {
     console.log('  ...cache miss, fetching...');
-    try {
-      const result = await getStatsForOrgMembers(initialQuery);
-      cache.save(result, 'json');
-      return result;
-    } catch (error) {
-      console.error(error);
-    }
+    const result = await getStatsForOrgMembers(initialQuery);
+    cache.save(result, 'json');
+    return result;
   }
 }


### PR DESCRIPTION
@bennypowers 

fixed the exception suppression we discussed.

in regards to the CODEOWNERS file,
I'm of the fence, please share your take on this.

as it's designed so far, you and/or me are listed as owners for all the core stuff.
the _about_, _community_, and _posts_ folders, has no owners.

I can modify this of course, this is just a suggestion.
WDYT?