### PR TITLE
feat: list repos on homepage

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -85,6 +85,22 @@ module.exports = function(eleventyConfig) {
     return filterTagList([...tagSet]);
   });
 
+  eleventyConfig.on('eleventy.before', async (e) => {
+    console.log('bundling <github-repository>');
+    const { build } = await import('esbuild');
+    await build({
+      bundle: true,
+      outfile: '_site/assets/gh.min.js',
+      minify: true,
+      format: 'esm',
+      stdin: {
+        contents: 'import "github-repository";',
+        sourcefile: 'github-repository.js',
+        resolveDir: path.join(__dirname, 'node_modules'),
+      }
+    });
+    console.log('  ...done');
+  });
   // Customize Markdown library and settings:
   let markdownLibrary = markdownIt({
     html: true,

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -13,6 +13,19 @@ const pluginNavigation = require("@11ty/eleventy-navigation");
 const PostCSSPlugin = require("eleventy-plugin-postcss");
 const RHDSPlugin = require("./_plugins/rhds.cjs");
 
+/**
+ * @see https://stackoverflow.com/a/12646864/2515275
+ * @license CC-BY-NC-SA 2.0 Laurens Holst
+ */
+function shuffleCopyArray(array) {
+  const copy = Array.from(array);
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
 module.exports = function(eleventyConfig) {
   // Copy the `assets` folder to the output
   eleventyConfig.addPassthroughCopy("assets");
@@ -26,6 +39,9 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPlugin(RHDSPlugin);
 
   eleventyConfig.addDataExtension("yaml", contents => yaml.load(contents));
+
+  eleventyConfig.addFilter("randomSort", /** @param {unknown[]} list */list =>
+    shuffleCopyArray(list));
 
   eleventyConfig.addFilter("readableDate", dateObj =>
     DateTime.fromJSDate(dateObj, {zone: 'Asia/Jerusalem', locale: 'he'})

--- a/_data/repos.yaml
+++ b/_data/repos.yaml
@@ -1,0 +1,5 @@
+- apollo-elements/apollo-elements
+- patternfly/patternfly-elements
+- redhat-ux/red-hat-design-system
+- redhat-ux/red-hat-design-tokens
+- redhat-israel/red-hat-israel-site

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -197,3 +197,12 @@ code {
 img {
   max-width: 100%;
 }
+
+#repos {
+  display: flex;
+  flex-flow: row wrap;
+  gap: var(--rh-space-md);
+  & h2 {
+    width: 100%;
+  }
+}

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -198,6 +198,10 @@ img {
   max-width: 100%;
 }
 
+#stats h2 {
+  grid-column: -1/1;
+}
+
 #repos {
   display: flex;
   flex-flow: row wrap;

--- a/index.html
+++ b/index.html
@@ -56,8 +56,7 @@ eleventyNavigation:
   <github-repository owner-repo="{{ repo }}"></github-repository>
   {% endfor %}
 </section>
-<script type="module"
-        src="https://unpkg.com/browse/github-repository@0.4.0/dist/github-repository.js?module"></script>
+<script type="module" src="https://unpkg.com/github-repository@0.4.0/dist/github-repository.js?module"></script>
 {% endif %}
 
 <h2>{% if maxPosts == 1 %}

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ eleventyNavigation:
 
 <section id="stats">
 
-  <p>בשנה האחרונה. עובדי רד האט בארץ תרמו לפרוייקטים שונים בגיטהאב...</p>
+  <h2>בשנה האחרונה. עובדי רד האט בארץ תרמו לפרוייקטים שונים בגיטהאב...</h2>
 
   <rh-stat top="statistic">
     <span slot="title">Commits</span>

--- a/index.html
+++ b/index.html
@@ -7,9 +7,9 @@ eleventyNavigation:
 {% set maxPosts = collections.posts.length | min(3) %}
 <img src="{{ '/assets/img/confetti.jpg' | url }}" alt="עובדי רד הט חוגגים עם קונפטי">
 
-<p>בשנה האחרונה. עובדי רד האט בארץ תרמו לפרוייקטים שונים בגיטהאב...</p>
+<section id="stats">
 
-<div id="stats">
+  <p>בשנה האחרונה. עובדי רד האט בארץ תרמו לפרוייקטים שונים בגיטהאב...</p>
 
   <rh-stat top="statistic">
     <span slot="title">Commits</span>
@@ -47,7 +47,18 @@ eleventyNavigation:
     <p slot="description"></p>
   </rh-stat>
 
-</div>
+</section>
+
+{% if (repos | length) > 0 %}
+<section id="repos">
+  <h2>מהפרוייקטים שאנחנו תורמי ם אליהם</h2>
+  {% for repo in repos | randomSort | slice(5) %}
+  <github-repository owner-repo="{{ repo }}"></github-repository>
+  {% endfor %}
+</section>
+<script type="module"
+        src="https://unpkg.com/browse/github-repository@0.4.0/dist/github-repository.js?module"></script>
+{% endif %}
 
 <h2>{% if maxPosts == 1 %}
   הפוסט האחרון {% else %}

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@ eleventyNavigation:
   <github-repository owner-repo="{{ repo }}"></github-repository>
   {% endfor %}
 </section>
-<script type="module" src="https://unpkg.com/github-repository@0.4.0/dist/github-repository.js?module"></script>
+<script type="module" src="{{ '/assets/gh.min.js' | url }}"></script>
 {% endif %}
 
 <h2>{% if maxPosts == 1 %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,8 @@
         "@rhds/tokens": "^1.0.0-beta.4",
         "dotenv": "^16.0.2",
         "eleventy-plugin-postcss": "^1.0.4",
+        "esbuild": "^0.15.13",
+        "github-repository": "^0.4.0",
         "postcss-preset-env": "^7.8.0"
       }
     },
@@ -195,6 +197,12 @@
       "bin": {
         "markdown-it": "bin/markdown-it.js"
       }
+    },
+    "node_modules/@abraham/reflection": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@abraham/reflection/-/reflection-0.7.0.tgz",
+      "integrity": "sha512-W4V4I0PzxeWCiMKnS4n4x3Fzb8cQp2qlmBO7RACS/00YsvIgijjcBz5Mp3P1PPP9vSzpbmi0qwuVYZ4twXKwxg==",
+      "dev": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
@@ -952,6 +960,38 @@
         "postcss-selector-parser": "^6.0.10"
       }
     },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.13.tgz",
+      "integrity": "sha512-RY2fVI8O0iFUNvZirXaQ1vMvK0xhCcl0gqRj74Z6yEiO1zAUa7hbsdwZM1kzqbxHK7LFyMizipfXT3JME+12Hw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.13.tgz",
+      "integrity": "sha512-+BoyIm4I8uJmH/QDIH0fu7MG0AEx9OXEDXnqptXCwKOlOqZiS4iraH1Nr7/ObLMokW3sOCeBNyD68ATcV9b9Ag==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -1140,6 +1180,25 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@nutmeg/seed": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@nutmeg/seed/-/seed-0.17.0.tgz",
+      "integrity": "sha512-VQFZomRTUZUFAIz+uCQAqgX2EGd8YDtQua2ddqSFL/oUN5b2Ocb+gjZnSKH5kz2IdsIPvoxaWK0AQNekLSMzRQ==",
+      "dev": true,
+      "dependencies": {
+        "@abraham/reflection": "0.7.0",
+        "lit-html": "1.1.2"
+      },
+      "engines": {
+        "node": "12"
+      }
+    },
+    "node_modules/@nutmeg/seed/node_modules/lit-html": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.1.2.tgz",
+      "integrity": "sha512-FFlUMKHKi+qG1x1iHNZ1hrtc/zHmfYTyrSvs3/wBTvaNtpZjOZGWzU7efGYVpgp6KvWeKF6ql9/KsCq6Z/mEDA==",
+      "dev": true
     },
     "node_modules/@octokit/endpoint": {
       "version": "7.0.1",
@@ -2155,6 +2214,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/approximate-number": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/approximate-number/-/approximate-number-2.0.0.tgz",
+      "integrity": "sha512-/8jyP/dd1q6KDBBuT7db0+8LacFD6/xCukGNQrpoQ4AoBkRzwcl8H2JZ7b3GI+Rh+iEaTzrjAb1IIkTB9CfyuQ==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3515,6 +3580,363 @@
       "integrity": "sha512-iC67eXHToclrlVhQfpRawDiF8D8sQxNxmbqw5oebegOaJkyx/w9C/k57/5e6yJR2zIByRt9OXdqX50DV2t6ZKw==",
       "dev": true
     },
+    "node_modules/esbuild": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.13.tgz",
+      "integrity": "sha512-Cu3SC84oyzzhrK/YyN4iEVy2jZu5t2fz66HEOShHURcjSkOSAVL8C/gfUT+lDJxkVHpg8GZ10DD0rMHRPqMFaQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.15.13",
+        "@esbuild/linux-loong64": "0.15.13",
+        "esbuild-android-64": "0.15.13",
+        "esbuild-android-arm64": "0.15.13",
+        "esbuild-darwin-64": "0.15.13",
+        "esbuild-darwin-arm64": "0.15.13",
+        "esbuild-freebsd-64": "0.15.13",
+        "esbuild-freebsd-arm64": "0.15.13",
+        "esbuild-linux-32": "0.15.13",
+        "esbuild-linux-64": "0.15.13",
+        "esbuild-linux-arm": "0.15.13",
+        "esbuild-linux-arm64": "0.15.13",
+        "esbuild-linux-mips64le": "0.15.13",
+        "esbuild-linux-ppc64le": "0.15.13",
+        "esbuild-linux-riscv64": "0.15.13",
+        "esbuild-linux-s390x": "0.15.13",
+        "esbuild-netbsd-64": "0.15.13",
+        "esbuild-openbsd-64": "0.15.13",
+        "esbuild-sunos-64": "0.15.13",
+        "esbuild-windows-32": "0.15.13",
+        "esbuild-windows-64": "0.15.13",
+        "esbuild-windows-arm64": "0.15.13"
+      }
+    },
+    "node_modules/esbuild-android-64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.13.tgz",
+      "integrity": "sha512-yRorukXBlokwTip+Sy4MYskLhJsO0Kn0/Fj43s1krVblfwP+hMD37a4Wmg139GEsMLl+vh8WXp2mq/cTA9J97g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.13.tgz",
+      "integrity": "sha512-TKzyymLD6PiVeyYa4c5wdPw87BeAiTXNtK6amWUcXZxkV51gOk5u5qzmDaYSwiWeecSNHamFsaFjLoi32QR5/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.13.tgz",
+      "integrity": "sha512-WAx7c2DaOS6CrRcoYCgXgkXDliLnFv3pQLV6GeW1YcGEZq2Gnl8s9Pg7ahValZkpOa0iE/ojRVQ87sbUhF1Cbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-arm64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.13.tgz",
+      "integrity": "sha512-U6jFsPfSSxC3V1CLiQqwvDuj3GGrtQNB3P3nNC3+q99EKf94UGpsG9l4CQ83zBs1NHrk1rtCSYT0+KfK5LsD8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.13.tgz",
+      "integrity": "sha512-whItJgDiOXaDG/idy75qqevIpZjnReZkMGCgQaBWZuKHoElDJC1rh7MpoUgupMcdfOd+PgdEwNQW9DAE6i8wyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.13.tgz",
+      "integrity": "sha512-6pCSWt8mLUbPtygv7cufV0sZLeylaMwS5Fznj6Rsx9G2AJJsAjQ9ifA+0rQEIg7DwJmi9it+WjzNTEAzzdoM3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.13.tgz",
+      "integrity": "sha512-VbZdWOEdrJiYApm2kkxoTOgsoCO1krBZ3quHdYk3g3ivWaMwNIVPIfEE0f0XQQ0u5pJtBsnk2/7OPiCFIPOe/w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.13.tgz",
+      "integrity": "sha512-rXmnArVNio6yANSqDQlIO4WiP+Cv7+9EuAHNnag7rByAqFVuRusLbGi2697A5dFPNXoO//IiogVwi3AdcfPC6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.13.tgz",
+      "integrity": "sha512-Ac6LpfmJO8WhCMQmO253xX2IU2B3wPDbl4IvR0hnqcPrdfCaUa2j/lLMGTjmQ4W5JsJIdHEdW12dG8lFS0MbxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.13.tgz",
+      "integrity": "sha512-alEMGU4Z+d17U7KQQw2IV8tQycO6T+rOrgW8OS22Ua25x6kHxoG6Ngry6Aq6uranC+pNWNMB6aHFPh7aTQdORQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.13.tgz",
+      "integrity": "sha512-47PgmyYEu+yN5rD/MbwS6DxP2FSGPo4Uxg5LwIdxTiyGC2XKwHhHyW7YYEDlSuXLQXEdTO7mYe8zQ74czP7W8A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.13.tgz",
+      "integrity": "sha512-z6n28h2+PC1Ayle9DjKoBRcx/4cxHoOa2e689e2aDJSaKug3jXcQw7mM+GLg+9ydYoNzj8QxNL8ihOv/OnezhA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-riscv64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.13.tgz",
+      "integrity": "sha512-+Lu4zuuXuQhgLUGyZloWCqTslcCAjMZH1k3Xc9MSEJEpEFdpsSU0sRDXAnk18FKOfEjhu4YMGaykx9xjtpA6ow==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-s390x": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.13.tgz",
+      "integrity": "sha512-BMeXRljruf7J0TMxD5CIXS65y7puiZkAh+s4XFV9qy16SxOuMhxhVIXYLnbdfLrsYGFzx7U9mcdpFWkkvy/Uag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-netbsd-64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.13.tgz",
+      "integrity": "sha512-EHj9QZOTel581JPj7UO3xYbltFTYnHy+SIqJVq6yd3KkCrsHRbapiPb0Lx3EOOtybBEE9EyqbmfW1NlSDsSzvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.13.tgz",
+      "integrity": "sha512-nkuDlIjF/sfUhfx8SKq0+U+Fgx5K9JcPq1mUodnxI0x4kBdCv46rOGWbuJ6eof2n3wdoCLccOoJAbg9ba/bT2w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.13.tgz",
+      "integrity": "sha512-jVeu2GfxZQ++6lRdY43CS0Tm/r4WuQQ0Pdsrxbw+aOrHQPHV0+LNOLnvbN28M7BSUGnJnHkHm2HozGgNGyeIRw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.13.tgz",
+      "integrity": "sha512-XoF2iBf0wnqo16SDq+aDGi/+QbaLFpkiRarPVssMh9KYbFNCqPLlGAWwDvxEVz+ywX6Si37J2AKm+AXq1kC0JA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.13.tgz",
+      "integrity": "sha512-Et6htEfGycjDrtqb2ng6nT+baesZPYQIW+HUEHK4D1ncggNrDNk3yoboYQ5KtiVrw/JaDMNttz8rrPubV/fvPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.13.tgz",
+      "integrity": "sha512-3bv7tqntThQC9SWLRouMDmZnlOukBhOCTlkzNqzGCmrkCJI7io5LLjwJBOVY6kOUlIvdxbooNZwjtBvj+7uuVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -3836,6 +4258,19 @@
       "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
       "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg==",
       "dev": true
+    },
+    "node_modules/github-repository": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/github-repository/-/github-repository-0.4.0.tgz",
+      "integrity": "sha512-p8Vpm5rIG54GGTjHLVE43GZrPTtdvGhoEX86nQVsqXvl0bIaj1R987WQGTjXtn5i4P1hIEMpgegpHLPbLWjXtQ==",
+      "dev": true,
+      "dependencies": {
+        "@nutmeg/seed": "0.17.0",
+        "approximate-number": "2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -8963,6 +9398,12 @@
         "normalize-path": "^3.0.0"
       }
     },
+    "@abraham/reflection": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@abraham/reflection/-/reflection-0.7.0.tgz",
+      "integrity": "sha512-W4V4I0PzxeWCiMKnS4n4x3Fzb8cQp2qlmBO7RACS/00YsvIgijjcBz5Mp3P1PPP9vSzpbmi0qwuVYZ4twXKwxg==",
+      "dev": true
+    },
     "@ampproject/remapping": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -9450,6 +9891,20 @@
       "dev": true,
       "requires": {}
     },
+    "@esbuild/android-arm": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.13.tgz",
+      "integrity": "sha512-RY2fVI8O0iFUNvZirXaQ1vMvK0xhCcl0gqRj74Z6yEiO1zAUa7hbsdwZM1kzqbxHK7LFyMizipfXT3JME+12Hw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-loong64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.13.tgz",
+      "integrity": "sha512-+BoyIm4I8uJmH/QDIH0fu7MG0AEx9OXEDXnqptXCwKOlOqZiS4iraH1Nr7/ObLMokW3sOCeBNyD68ATcV9b9Ag==",
+      "dev": true,
+      "optional": true
+    },
     "@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -9613,6 +10068,24 @@
       "requires": {
         "mkdirp": "^1.0.4",
         "rimraf": "^3.0.2"
+      }
+    },
+    "@nutmeg/seed": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@nutmeg/seed/-/seed-0.17.0.tgz",
+      "integrity": "sha512-VQFZomRTUZUFAIz+uCQAqgX2EGd8YDtQua2ddqSFL/oUN5b2Ocb+gjZnSKH5kz2IdsIPvoxaWK0AQNekLSMzRQ==",
+      "dev": true,
+      "requires": {
+        "@abraham/reflection": "0.7.0",
+        "lit-html": "1.1.2"
+      },
+      "dependencies": {
+        "lit-html": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.1.2.tgz",
+          "integrity": "sha512-FFlUMKHKi+qG1x1iHNZ1hrtc/zHmfYTyrSvs3/wBTvaNtpZjOZGWzU7efGYVpgp6KvWeKF6ql9/KsCq6Z/mEDA==",
+          "dev": true
+        }
       }
     },
     "@octokit/endpoint": {
@@ -10616,6 +11089,12 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "approximate-number": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/approximate-number/-/approximate-number-2.0.0.tgz",
+      "integrity": "sha512-/8jyP/dd1q6KDBBuT7db0+8LacFD6/xCukGNQrpoQ4AoBkRzwcl8H2JZ7b3GI+Rh+iEaTzrjAb1IIkTB9CfyuQ==",
+      "dev": true
     },
     "argparse": {
       "version": "2.0.1",
@@ -11633,6 +12112,176 @@
       "integrity": "sha512-iC67eXHToclrlVhQfpRawDiF8D8sQxNxmbqw5oebegOaJkyx/w9C/k57/5e6yJR2zIByRt9OXdqX50DV2t6ZKw==",
       "dev": true
     },
+    "esbuild": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.13.tgz",
+      "integrity": "sha512-Cu3SC84oyzzhrK/YyN4iEVy2jZu5t2fz66HEOShHURcjSkOSAVL8C/gfUT+lDJxkVHpg8GZ10DD0rMHRPqMFaQ==",
+      "dev": true,
+      "requires": {
+        "@esbuild/android-arm": "0.15.13",
+        "@esbuild/linux-loong64": "0.15.13",
+        "esbuild-android-64": "0.15.13",
+        "esbuild-android-arm64": "0.15.13",
+        "esbuild-darwin-64": "0.15.13",
+        "esbuild-darwin-arm64": "0.15.13",
+        "esbuild-freebsd-64": "0.15.13",
+        "esbuild-freebsd-arm64": "0.15.13",
+        "esbuild-linux-32": "0.15.13",
+        "esbuild-linux-64": "0.15.13",
+        "esbuild-linux-arm": "0.15.13",
+        "esbuild-linux-arm64": "0.15.13",
+        "esbuild-linux-mips64le": "0.15.13",
+        "esbuild-linux-ppc64le": "0.15.13",
+        "esbuild-linux-riscv64": "0.15.13",
+        "esbuild-linux-s390x": "0.15.13",
+        "esbuild-netbsd-64": "0.15.13",
+        "esbuild-openbsd-64": "0.15.13",
+        "esbuild-sunos-64": "0.15.13",
+        "esbuild-windows-32": "0.15.13",
+        "esbuild-windows-64": "0.15.13",
+        "esbuild-windows-arm64": "0.15.13"
+      }
+    },
+    "esbuild-android-64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.13.tgz",
+      "integrity": "sha512-yRorukXBlokwTip+Sy4MYskLhJsO0Kn0/Fj43s1krVblfwP+hMD37a4Wmg139GEsMLl+vh8WXp2mq/cTA9J97g==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-android-arm64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.13.tgz",
+      "integrity": "sha512-TKzyymLD6PiVeyYa4c5wdPw87BeAiTXNtK6amWUcXZxkV51gOk5u5qzmDaYSwiWeecSNHamFsaFjLoi32QR5/w==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-darwin-64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.13.tgz",
+      "integrity": "sha512-WAx7c2DaOS6CrRcoYCgXgkXDliLnFv3pQLV6GeW1YcGEZq2Gnl8s9Pg7ahValZkpOa0iE/ojRVQ87sbUhF1Cbg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-darwin-arm64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.13.tgz",
+      "integrity": "sha512-U6jFsPfSSxC3V1CLiQqwvDuj3GGrtQNB3P3nNC3+q99EKf94UGpsG9l4CQ83zBs1NHrk1rtCSYT0+KfK5LsD8A==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-freebsd-64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.13.tgz",
+      "integrity": "sha512-whItJgDiOXaDG/idy75qqevIpZjnReZkMGCgQaBWZuKHoElDJC1rh7MpoUgupMcdfOd+PgdEwNQW9DAE6i8wyA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-freebsd-arm64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.13.tgz",
+      "integrity": "sha512-6pCSWt8mLUbPtygv7cufV0sZLeylaMwS5Fznj6Rsx9G2AJJsAjQ9ifA+0rQEIg7DwJmi9it+WjzNTEAzzdoM3Q==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-32": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.13.tgz",
+      "integrity": "sha512-VbZdWOEdrJiYApm2kkxoTOgsoCO1krBZ3quHdYk3g3ivWaMwNIVPIfEE0f0XQQ0u5pJtBsnk2/7OPiCFIPOe/w==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.13.tgz",
+      "integrity": "sha512-rXmnArVNio6yANSqDQlIO4WiP+Cv7+9EuAHNnag7rByAqFVuRusLbGi2697A5dFPNXoO//IiogVwi3AdcfPC6A==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-arm": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.13.tgz",
+      "integrity": "sha512-Ac6LpfmJO8WhCMQmO253xX2IU2B3wPDbl4IvR0hnqcPrdfCaUa2j/lLMGTjmQ4W5JsJIdHEdW12dG8lFS0MbxQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-arm64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.13.tgz",
+      "integrity": "sha512-alEMGU4Z+d17U7KQQw2IV8tQycO6T+rOrgW8OS22Ua25x6kHxoG6Ngry6Aq6uranC+pNWNMB6aHFPh7aTQdORQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-mips64le": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.13.tgz",
+      "integrity": "sha512-47PgmyYEu+yN5rD/MbwS6DxP2FSGPo4Uxg5LwIdxTiyGC2XKwHhHyW7YYEDlSuXLQXEdTO7mYe8zQ74czP7W8A==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-ppc64le": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.13.tgz",
+      "integrity": "sha512-z6n28h2+PC1Ayle9DjKoBRcx/4cxHoOa2e689e2aDJSaKug3jXcQw7mM+GLg+9ydYoNzj8QxNL8ihOv/OnezhA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-riscv64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.13.tgz",
+      "integrity": "sha512-+Lu4zuuXuQhgLUGyZloWCqTslcCAjMZH1k3Xc9MSEJEpEFdpsSU0sRDXAnk18FKOfEjhu4YMGaykx9xjtpA6ow==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-s390x": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.13.tgz",
+      "integrity": "sha512-BMeXRljruf7J0TMxD5CIXS65y7puiZkAh+s4XFV9qy16SxOuMhxhVIXYLnbdfLrsYGFzx7U9mcdpFWkkvy/Uag==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-netbsd-64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.13.tgz",
+      "integrity": "sha512-EHj9QZOTel581JPj7UO3xYbltFTYnHy+SIqJVq6yd3KkCrsHRbapiPb0Lx3EOOtybBEE9EyqbmfW1NlSDsSzvQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-openbsd-64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.13.tgz",
+      "integrity": "sha512-nkuDlIjF/sfUhfx8SKq0+U+Fgx5K9JcPq1mUodnxI0x4kBdCv46rOGWbuJ6eof2n3wdoCLccOoJAbg9ba/bT2w==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-sunos-64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.13.tgz",
+      "integrity": "sha512-jVeu2GfxZQ++6lRdY43CS0Tm/r4WuQQ0Pdsrxbw+aOrHQPHV0+LNOLnvbN28M7BSUGnJnHkHm2HozGgNGyeIRw==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-32": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.13.tgz",
+      "integrity": "sha512-XoF2iBf0wnqo16SDq+aDGi/+QbaLFpkiRarPVssMh9KYbFNCqPLlGAWwDvxEVz+ywX6Si37J2AKm+AXq1kC0JA==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.13.tgz",
+      "integrity": "sha512-Et6htEfGycjDrtqb2ng6nT+baesZPYQIW+HUEHK4D1ncggNrDNk3yoboYQ5KtiVrw/JaDMNttz8rrPubV/fvPQ==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-windows-arm64": {
+      "version": "0.15.13",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.13.tgz",
+      "integrity": "sha512-3bv7tqntThQC9SWLRouMDmZnlOukBhOCTlkzNqzGCmrkCJI7io5LLjwJBOVY6kOUlIvdxbooNZwjtBvj+7uuVg==",
+      "dev": true,
+      "optional": true
+    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -11876,6 +12525,16 @@
       "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
       "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg==",
       "dev": true
+    },
+    "github-repository": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/github-repository/-/github-repository-0.4.0.tgz",
+      "integrity": "sha512-p8Vpm5rIG54GGTjHLVE43GZrPTtdvGhoEX86nQVsqXvl0bIaj1R987WQGTjXtn5i4P1hIEMpgegpHLPbLWjXtQ==",
+      "dev": true,
+      "requires": {
+        "@nutmeg/seed": "0.17.0",
+        "approximate-number": "2.0.0"
+      }
     },
     "glob": {
       "version": "7.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1830,9 +1830,9 @@
       "dev": true
     },
     "node_modules/@rhds/elements": {
-      "version": "1.0.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@rhds/elements/-/elements-1.0.0-beta.18.tgz",
-      "integrity": "sha512-S7wVPjDnn1phBx6xuAGejDg9tGsvR0H/O4cb06v5+lt4TTgwaeScVrSXc9fTNRqtXUBRD8a4iUw+Ut0XfBZ/WA==",
+      "version": "1.0.0-beta.23",
+      "resolved": "https://registry.npmjs.org/@rhds/elements/-/elements-1.0.0-beta.23.tgz",
+      "integrity": "sha512-MJYPj6vVjoTnc73aIyEjkeP56EIQGjE01fbOa3j3socZJ9DAjrRqxn7+2UOiqPOJSjrWAVbei/SIsF4mRYC9Tw==",
       "dev": true,
       "dependencies": {
         "@patternfly/pfe-accordion": "next",
@@ -1866,9 +1866,9 @@
       }
     },
     "node_modules/@rhds/tokens": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@rhds/tokens/-/tokens-1.0.0-beta.4.tgz",
-      "integrity": "sha512-qV5RRR1avU+i9uWRFTe76N5WRNiHnpcCqXHUC7/3LaVJhkPds/wtsBf0zBEZOzxbtBsV6UDHMoAg2kf4WgkIyQ==",
+      "version": "1.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@rhds/tokens/-/tokens-1.0.0-beta.9.tgz",
+      "integrity": "sha512-RvRPGOozZ6Zp+EURmKcOB3LNCzBvzYYUGWbbHMlRWq4foLu2cmZiNbsN8tNp39kFUUWAytyD9fuhvUthEv8EUg==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0",
@@ -3774,19 +3774,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -10328,9 +10315,9 @@
       "dev": true
     },
     "@rhds/elements": {
-      "version": "1.0.0-beta.18",
-      "resolved": "https://registry.npmjs.org/@rhds/elements/-/elements-1.0.0-beta.18.tgz",
-      "integrity": "sha512-S7wVPjDnn1phBx6xuAGejDg9tGsvR0H/O4cb06v5+lt4TTgwaeScVrSXc9fTNRqtXUBRD8a4iUw+Ut0XfBZ/WA==",
+      "version": "1.0.0-beta.23",
+      "resolved": "https://registry.npmjs.org/@rhds/elements/-/elements-1.0.0-beta.23.tgz",
+      "integrity": "sha512-MJYPj6vVjoTnc73aIyEjkeP56EIQGjE01fbOa3j3socZJ9DAjrRqxn7+2UOiqPOJSjrWAVbei/SIsF4mRYC9Tw==",
       "dev": true,
       "requires": {
         "@patternfly/pfe-accordion": "next",
@@ -10364,9 +10351,9 @@
       }
     },
     "@rhds/tokens": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@rhds/tokens/-/tokens-1.0.0-beta.4.tgz",
-      "integrity": "sha512-qV5RRR1avU+i9uWRFTe76N5WRNiHnpcCqXHUC7/3LaVJhkPds/wtsBf0zBEZOzxbtBsV6UDHMoAg2kf4WgkIyQ==",
+      "version": "1.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@rhds/tokens/-/tokens-1.0.0-beta.9.tgz",
+      "integrity": "sha512-RvRPGOozZ6Zp+EURmKcOB3LNCzBvzYYUGWbbHMlRWq4foLu2cmZiNbsN8tNp39kFUUWAytyD9fuhvUthEv8EUg==",
       "dev": true,
       "requires": {
         "postcss-value-parser": "^4.2.0",
@@ -11813,12 +11800,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       },
       "devDependencies": {
         "@jspm/generator": "^1.0.0-beta.33",
-        "@rhds/elements": "^1.0.0-beta.18",
+        "@rhds/elements": "^1.0.0-beta.24",
         "@rhds/tokens": "^1.0.0-beta.4",
         "dotenv": "^16.0.2",
         "eleventy-plugin-postcss": "^1.0.4",
@@ -1390,9 +1390,9 @@
       }
     },
     "node_modules/@patternfly/pfe-core": {
-      "version": "2.0.0-next.8",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-core/-/pfe-core-2.0.0-next.8.tgz",
-      "integrity": "sha512-FFXmMMHm4Y2mC9jniznm5gBLjmlGVVekZ2IBmAqssZUdKh8+TkTkio7kq3uT7BjtjArAixy0W0XPd9L+DYizPA==",
+      "version": "2.0.0-next.10",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-core/-/pfe-core-2.0.0-next.10.tgz",
+      "integrity": "sha512-9ySuUTaUk/rwrPj/2nHFPxbSL3IFfGmYkRalLJ5LTHzNJbxIbDaRODLSPfSyMhg1q2Sdb4StIglyupttx6nNWg==",
       "dev": true,
       "dependencies": {
         "@popperjs/core": "2.11.6",
@@ -1696,6 +1696,27 @@
         "lit-html": "^2.3.0"
       }
     },
+    "node_modules/@patternfly/pfe-spinner": {
+      "version": "2.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-spinner/-/pfe-spinner-2.0.0-next.5.tgz",
+      "integrity": "sha512-oxxfg5SkDHd6SJ1DeyFydYB3mhSFnWAhziIuFeznT88B6WfISfcrWz14LoM3ivdiA+47oPGYApe9LrP8V1qj+A==",
+      "dev": true,
+      "dependencies": {
+        "@patternfly/pfe-core": "^2.0.0-next.9",
+        "lit": "2.3.0"
+      }
+    },
+    "node_modules/@patternfly/pfe-spinner/node_modules/lit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.3.0.tgz",
+      "integrity": "sha512-ynSGsUYKSGN2weFQ1F3SZq0Ihlj+vr/3KAET//Yf8Tz86L7lZizlw9Px+ab5iN8Si4RkVoLqd9YtKQmjdyKHNg==",
+      "dev": true,
+      "dependencies": {
+        "@lit/reactive-element": "^1.4.0",
+        "lit-element": "^3.2.0",
+        "lit-html": "^2.3.0"
+      }
+    },
     "node_modules/@patternfly/pfe-styles": {
       "version": "2.0.0-next.3",
       "resolved": "https://registry.npmjs.org/@patternfly/pfe-styles/-/pfe-styles-2.0.0-next.3.tgz",
@@ -1830,9 +1851,9 @@
       "dev": true
     },
     "node_modules/@rhds/elements": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@rhds/elements/-/elements-1.0.0-beta.23.tgz",
-      "integrity": "sha512-MJYPj6vVjoTnc73aIyEjkeP56EIQGjE01fbOa3j3socZJ9DAjrRqxn7+2UOiqPOJSjrWAVbei/SIsF4mRYC9Tw==",
+      "version": "1.0.0-beta.24",
+      "resolved": "https://registry.npmjs.org/@rhds/elements/-/elements-1.0.0-beta.24.tgz",
+      "integrity": "sha512-5N9iJDmuSVQIGidMuF3R8IbWTcRNtZ/e76l86W/0xh1qDT/iAnJobAqFGBqcUiSepVXxbL+Hl2tJJ5OG1lX4Zg==",
       "dev": true,
       "dependencies": {
         "@patternfly/pfe-accordion": "next",
@@ -1854,8 +1875,8 @@
         "@patternfly/pfe-modal": "next",
         "@patternfly/pfe-number": "next",
         "@patternfly/pfe-page-status": "next",
-        "@patternfly/pfe-progress-indicator": "next",
         "@patternfly/pfe-select": "next",
+        "@patternfly/pfe-spinner": "next",
         "@patternfly/pfe-styles": "next",
         "@patternfly/pfe-tabs": "next",
         "@patternfly/pfe-toast": "next",
@@ -9847,9 +9868,9 @@
       }
     },
     "@patternfly/pfe-core": {
-      "version": "2.0.0-next.8",
-      "resolved": "https://registry.npmjs.org/@patternfly/pfe-core/-/pfe-core-2.0.0-next.8.tgz",
-      "integrity": "sha512-FFXmMMHm4Y2mC9jniznm5gBLjmlGVVekZ2IBmAqssZUdKh8+TkTkio7kq3uT7BjtjArAixy0W0XPd9L+DYizPA==",
+      "version": "2.0.0-next.10",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-core/-/pfe-core-2.0.0-next.10.tgz",
+      "integrity": "sha512-9ySuUTaUk/rwrPj/2nHFPxbSL3IFfGmYkRalLJ5LTHzNJbxIbDaRODLSPfSyMhg1q2Sdb4StIglyupttx6nNWg==",
       "dev": true,
       "requires": {
         "@popperjs/core": "2.11.6",
@@ -10181,6 +10202,29 @@
         }
       }
     },
+    "@patternfly/pfe-spinner": {
+      "version": "2.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/@patternfly/pfe-spinner/-/pfe-spinner-2.0.0-next.5.tgz",
+      "integrity": "sha512-oxxfg5SkDHd6SJ1DeyFydYB3mhSFnWAhziIuFeznT88B6WfISfcrWz14LoM3ivdiA+47oPGYApe9LrP8V1qj+A==",
+      "dev": true,
+      "requires": {
+        "@patternfly/pfe-core": "^2.0.0-next.9",
+        "lit": "2.3.0"
+      },
+      "dependencies": {
+        "lit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/lit/-/lit-2.3.0.tgz",
+          "integrity": "sha512-ynSGsUYKSGN2weFQ1F3SZq0Ihlj+vr/3KAET//Yf8Tz86L7lZizlw9Px+ab5iN8Si4RkVoLqd9YtKQmjdyKHNg==",
+          "dev": true,
+          "requires": {
+            "@lit/reactive-element": "^1.4.0",
+            "lit-element": "^3.2.0",
+            "lit-html": "^2.3.0"
+          }
+        }
+      }
+    },
     "@patternfly/pfe-styles": {
       "version": "2.0.0-next.3",
       "resolved": "https://registry.npmjs.org/@patternfly/pfe-styles/-/pfe-styles-2.0.0-next.3.tgz",
@@ -10315,9 +10359,9 @@
       "dev": true
     },
     "@rhds/elements": {
-      "version": "1.0.0-beta.23",
-      "resolved": "https://registry.npmjs.org/@rhds/elements/-/elements-1.0.0-beta.23.tgz",
-      "integrity": "sha512-MJYPj6vVjoTnc73aIyEjkeP56EIQGjE01fbOa3j3socZJ9DAjrRqxn7+2UOiqPOJSjrWAVbei/SIsF4mRYC9Tw==",
+      "version": "1.0.0-beta.24",
+      "resolved": "https://registry.npmjs.org/@rhds/elements/-/elements-1.0.0-beta.24.tgz",
+      "integrity": "sha512-5N9iJDmuSVQIGidMuF3R8IbWTcRNtZ/e76l86W/0xh1qDT/iAnJobAqFGBqcUiSepVXxbL+Hl2tJJ5OG1lX4Zg==",
       "dev": true,
       "requires": {
         "@patternfly/pfe-accordion": "next",
@@ -10339,8 +10383,8 @@
         "@patternfly/pfe-modal": "next",
         "@patternfly/pfe-number": "next",
         "@patternfly/pfe-page-status": "next",
-        "@patternfly/pfe-progress-indicator": "next",
         "@patternfly/pfe-select": "next",
+        "@patternfly/pfe-spinner": "next",
         "@patternfly/pfe-styles": "next",
         "@patternfly/pfe-tabs": "next",
         "@patternfly/pfe-toast": "next",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@jspm/generator": "^1.0.0-beta.33",
-    "@rhds/elements": "^1.0.0-beta.18",
+    "@rhds/elements": "^1.0.0-beta.24",
     "@rhds/tokens": "^1.0.0-beta.4",
     "dotenv": "^16.0.2",
     "eleventy-plugin-postcss": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "@rhds/tokens": "^1.0.0-beta.4",
     "dotenv": "^16.0.2",
     "eleventy-plugin-postcss": "^1.0.4",
+    "esbuild": "^0.15.13",
+    "github-repository": "^0.4.0",
     "postcss-preset-env": "^7.8.0"
   }
 }


### PR DESCRIPTION
Add new repos to `_data/repos.yaml`. They're randomly chosen each build and the first five are displayed. the details are fetched from github on the _client-side_. we can choose down the line to reimplement the web component here and fetch data server side, but IMHO that's neither a blocker or necessarily the ideal choice. what might be nice though would be paginating the results instead of picking randomly. we have `<rh-pagination>` now, too