### PR TITLE
fix: repo list

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -52,6 +52,10 @@ module.exports = function(eleventyConfig) {
     return DateTime.fromJSDate(dateObj, {zone: 'utc'}).toFormat('yyyy-LL-dd');
   });
 
+  // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-date-string
+  eleventyConfig.addFilter('pick', /** @param {unknown[]} list */(list, count) =>
+    Array.from(list).slice(0, count));
+
   // Get the first `n` elements of a collection.
   eleventyConfig.addFilter("head", (array, n) => {
     if(!Array.isArray(array) || array.length === 0) {

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@ eleventyNavigation:
 {% if (repos | length) > 0 %}
 <section id="repos">
   <h2>מהפרוייקטים שאנחנו תורמי ם אליהם</h2>
-  {% for repo in repos | randomSort | slice(5) %}
+  {% for repo in repos | randomSort | pick(5) %}
   <github-repository owner-repo="{{ repo }}"></github-repository>
   {% endfor %}
 </section>


### PR DESCRIPTION
replace nunjuck's built-in [slice](https://mozilla.github.io/nunjucks/templating.html#slice) filter with javascript [Array slice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice)

used the `log` filter to check that `repos` list was indeed ok, and that it was in fact the njk built-in slice that caused the problem.

so now we have a `pick(int)` filter for use in templates

